### PR TITLE
Some minor optimizations

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -18,7 +18,7 @@ pub fn generate_random_evaluation(
     // Generate random vector
     let mut rng = test_rng();
     let degree = 1<<input_domain_dim-1;
-    let mut rand_vec: Vec<Fr> = vec![];
+    let mut rand_vec: Vec<Fr> = Vec::with_capacity(degree);
     for _i in 0..degree {
         rand_vec.push(Fr::rand(&mut rng));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::prelude::*;
 pub fn bench_fft_and_ifft(input_domain_dim: usize, output_domain_dim: usize) {
     let (rand_evaluation_domain, output_domain) = fft::generate_random_evaluation(input_domain_dim, output_domain_dim);
 
-    fft::compute_fft_and_ifft(rand_evaluation_domain.clone(), output_domain);
+    fft::compute_fft_and_ifft(rand_evaluation_domain, output_domain);
 }
 
 #[wasm_bindgen]

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -12,8 +12,8 @@ pub fn generate_pairing_inputs(size: usize)
 -> (Vec<G1Projective>, Vec<G2Projective>)
 {
     let mut rng = test_rng();
-    let mut g1_rand_vec = vec![];
-    let mut g2_rand_vec = vec![];
+    let mut g1_rand_vec = Vec::with_capacity(size);
+    let mut g2_rand_vec = Vec::with_capacity(size);
     
     for _i in 0..size {
         let a: G1Projective = rng.gen();
@@ -28,7 +28,7 @@ pub fn generate_pairing_inputs(size: usize)
 pub fn compute_billinearity(g1_vector: Vec<G1Projective>, g2_vector: Vec<G2Projective>) {
     assert!(g1_vector.len() == g2_vector.len(), "Length of g1 vector and g2 vector should be the same");
     let size = g1_vector.len();
-    let mut res_vec = vec![];
+    let mut res_vec = Vec::with_capacity(size);
     for _i in 0..size {
         let res = Bls12_381::pairing(g1_vector[_i], g2_vector[_i]);
         res_vec.push(res);


### PR DESCRIPTION
Signed-off-by: Dengjianping <djptux@gmail.com>

It's not that reasonable to extend vector by each loop, we can allocate it just one time.
```
vec![] -> Vec::with_capacity(size)
```
Hope it can improve the performance.