### PR TITLE
MSM inputs as JS objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "lib"]
 # wasm dependencies
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"]}
+js-sys = "0.3.58"
 
 # crypto dependencies
 rand_chacha = { version = "0.3.1", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@ impl PointVectorInput {
             let y = point.y;
             let is_infinity = point.infinity;
 
-            let mut x_bytes: Vec<u8> = Vec::with_capacity(384);
+            let mut x_bytes: Vec<u8> = Vec::with_capacity(48);
             x.write(&mut x_bytes).unwrap();
-            let mut y_bytes: Vec<u8> = Vec::with_capacity(384);
+            let mut y_bytes: Vec<u8> = Vec::with_capacity(48);
             y.write(&mut y_bytes).unwrap();
 
             let point = Array::new_with_length(3);
@@ -61,7 +61,7 @@ impl ScalarVectorInput {
     pub fn to_js_array(&self) -> Array {
         let arr = Array::new_with_length(self.scalar_vec.len() as u32);
         for (i, scalar) in (&self.scalar_vec).into_iter().enumerate() {
-            let mut bytes: Vec<u8> = Vec::with_capacity(256);
+            let mut bytes: Vec<u8> = Vec::with_capacity(32);
             scalar.write(&mut bytes).unwrap();
             arr.set(i as u32, Uint8Array::from(bytes.as_slice()).into());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use ark_bls12_381::G1Affine;
 use ark_ec::{AffineCurve, ProjectiveCurve};
-use ark_ff::PrimeField;
+use ark_ff::{PrimeField, ToBytes};
+use js_sys::{Array, Uint8Array};
 use wasm_bindgen::prelude::*;
 
 pub mod msm;
@@ -16,9 +17,29 @@ impl PointVectorInput {
     pub fn new(size: usize) -> Self {
         let (point_vec, _) = msm::generate_msm_inputs(size);
 
-        Self {
-            point_vec,
+        Self { point_vec }
+    }
+
+    #[wasm_bindgen(js_name = "toJsArray")]
+    pub fn to_js_array(&self) -> Array {
+        let arr = Array::new_with_length(self.point_vec.len() as u32);
+        for (i, point) in (&self.point_vec).into_iter().enumerate() {
+            let x = point.x;
+            let y = point.y;
+            let is_infinity = point.infinity;
+
+            let mut x_bytes: Vec<u8> = Vec::with_capacity(384);
+            x.write(&mut x_bytes).unwrap();
+            let mut y_bytes: Vec<u8> = Vec::with_capacity(384);
+            y.write(&mut y_bytes).unwrap();
+
+            let point = Array::new_with_length(3);
+            point.set(0, Uint8Array::from(x_bytes.as_slice()).into());
+            point.set(1, Uint8Array::from(y_bytes.as_slice()).into());
+            point.set(2, is_infinity.into());
+            arr.set(i as u32, point.into());
         }
+        arr
     }
 }
 
@@ -33,9 +54,18 @@ impl ScalarVectorInput {
     pub fn new(size: usize) -> Self {
         let (_, scalar_vec) = msm::generate_msm_inputs(size);
 
-        Self {
-            scalar_vec,
+        Self { scalar_vec }
+    }
+
+    #[wasm_bindgen(js_name = "toJsArray")]
+    pub fn to_js_array(&self) -> Array {
+        let arr = Array::new_with_length(self.scalar_vec.len() as u32);
+        for (i, scalar) in (&self.scalar_vec).into_iter().enumerate() {
+            let mut bytes: Vec<u8> = Vec::with_capacity(256);
+            scalar.write(&mut bytes).unwrap();
+            arr.set(i as u32, Uint8Array::from(bytes.as_slice()).into());
         }
+        arr
     }
 }
 


### PR DESCRIPTION
this adds a method `.toJsArray()` to both `PointVectorInput` and `ScalarVectorInput`, to read them out of the evaluator's Wasm memory and be able to pass them to participant code.

example code:
```js
let points = new PointVectorInput();
let jsPoints = points.toJsArray();
```

jsPoints is of type `Array<[Uint8Array, Uint8Array, bool]>`, so each point is a triple (array of length 3) `[Uint8Array, Uint8Array, bool]` where the two Uint8arrays are the x and y coordinates of a point, and the `bool` indicates whether this is the point at infinity. The two Uint8Arrays have a length of 48 corresponding the rounded-up bit length of 384 bits for curve points.

`ScalarVectorInput.toJsArray()` is a bit simpler, it returns an array of Uint8Arrays of length 32 (to hold 255 bits for each scalar).

Here are some timings for $n= 2^{14}$ to get an idea for how such a conversion could affect performance:
```
create inputs: 25.497 sec
convert inputs to js: 0.039 sec
msm (Rust reference impl): 1.702 sec
```

we observe that copying & conversion of inputs to a JS object takes `0.039 sec`, which would be ~2% of the MSM runtime of `1.702 sec`.

IMO, 2% is large enough to potentially determine/skew the outcome of the competition, so it probably shouldn't be part of the time measurements. (or if it is, this should be a deliberate choice that's made explicit to participants)
